### PR TITLE
Clear jokes

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -135,6 +135,11 @@ function getJokes () {
     
 }
 
+// function to clear jokesCardArray
+function clearJokesCardArray () {
+    console.log("cleared");
+}
+
 // USER INTERACTIONS
 
 
@@ -144,5 +149,7 @@ function getJokes () {
 // event listener for modal launch button
 $('#jokesButton').on('click', launchJokesModal);
 
+// event listener for modal close button
+$('#jokesClose').on('click', clearJokesCardArray);
 
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -135,9 +135,12 @@ function getJokes () {
     
 }
 
-// function to clear jokesCardArray
-function clearJokesCardArray () {
+// function to clear jokesCardContainer
+function clearJokesCardContainer () {
     console.log("cleared");
+
+    const jokesCardContainer = $('#jokesModalBody');
+    jokesCardContainer.empty();
 }
 
 // USER INTERACTIONS
@@ -150,6 +153,6 @@ function clearJokesCardArray () {
 $('#jokesButton').on('click', launchJokesModal);
 
 // event listener for modal close button
-$('#jokesClose').on('click', clearJokesCardArray);
+$('#jokesClose').on('click', clearJokesCardContainer);
 
 

--- a/results.html
+++ b/results.html
@@ -45,7 +45,7 @@
                         <div id=jokesModalBody class="modal-body">
                         </div>
                         <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                        <button id="jokesClose" type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
                         </div>
                     </div>
                     </div>


### PR DESCRIPTION
## Purpose

The jokes modal was ever expanding instead of clearing on close - this clears it on close.

Fixes #59 

## Changes

added an event listener to the close button and added a function that clears the jokes modal body.
![image](https://github.com/adammathis05/dad-dinner/assets/169301676/00194ded-dec1-4e95-b0bf-5dd0e0a05a2c)


## Steps to Reproduce or Test

preview the results.html and hit the Make these kids laugh button, then hit close, and hit the make these kids laugh button again, 5 new jokes should appear each time you close and open it.
